### PR TITLE
fix : 통합테스트에서 발생하는 오류 수정

### DIFF
--- a/src/main/java/lotto/model/Lotto.java
+++ b/src/main/java/lotto/model/Lotto.java
@@ -4,6 +4,8 @@ import static lotto.model.constant.LottoMessageConstant.END_BRACKET;
 import static lotto.model.constant.LottoMessageConstant.NUMBER_DELIMITER;
 import static lotto.model.constant.LottoMessageConstant.START_BRACKET;
 
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import lotto.util.LottoValidator;
@@ -17,7 +19,11 @@ public class Lotto {
 
     public Lotto(List<Integer> lottoNumberInput) {
         isValidLottoNumbers(lottoNumberInput);
-        this.numbers = lottoNumberInput.stream().map(LottoNumber::new).toList();
+        numbers = new ArrayList<>();
+        for (Integer integer : lottoNumberInput) {
+            numbers.add(new LottoNumber(integer));
+        }
+        numbers.sort(Comparator.comparingInt(LottoNumber::getNumber));
     }
 
     public void isValidLottoNumbers(List<Integer> lottoNumberInput) {

--- a/src/main/java/lotto/model/LottoGenerator.java
+++ b/src/main/java/lotto/model/LottoGenerator.java
@@ -1,7 +1,6 @@
 package lotto.model;
 
 import camp.nextstep.edu.missionutils.Randoms;
-import java.util.Collections;
 import java.util.List;
 
 public class LottoGenerator {
@@ -17,7 +16,6 @@ public class LottoGenerator {
 
     public Lotto generate() {
         List<Integer> lottoNumbers = Randoms.pickUniqueNumbersInRange(1, 45, 6);
-        Collections.sort(lottoNumbers);
         return new Lotto(lottoNumbers);
     }
 

--- a/src/main/java/lotto/model/constant/LottoMessageConstant.java
+++ b/src/main/java/lotto/model/constant/LottoMessageConstant.java
@@ -3,7 +3,7 @@ package lotto.model.constant;
 public enum LottoMessageConstant {
 
     START_BRACKET("["),
-    NUMBER_DELIMITER(" ,"),
+    NUMBER_DELIMITER(", "),
     END_BRACKET("]");
 
     private final String constant;


### PR DESCRIPTION
## 🧑‍💻 작업 내용
> 작업한 내용 정리
- 통합테스트에서 발생하는 오류 수정
   - 로또 번호 출력시 오류 발생
      - 현재 : `[1 ,3 ,5 ,14 ,22 ,45]`
      - 정답 : `[1, 3, 5, 14, 22, 45]`

   - 통합 테스트에서 불변 객체를 넘길때 생기는 오류 수정
      - 구매한 로또의 정렬을 stream 이 아닌 새로운 객체를 생성해서 정렬하는 방식으로 변경

<br>

## 🚀 이슈
> 발생 이슈 없을시 생략 가능
- 테스트 코드 작성
- 리팩토링




<br>
